### PR TITLE
Fix build error caused by new metadata types

### DIFF
--- a/mdms/mdms-metanome/src/main/java/de/hpi/isg/mdms/metanome/MetacrateResultReceiver.java
+++ b/mdms/mdms-metanome/src/main/java/de/hpi/isg/mdms/metanome/MetacrateResultReceiver.java
@@ -90,6 +90,36 @@ public class MetacrateResultReceiver implements OmniscientResultReceiver, AutoCl
         return false;
     }
 
+    @Override
+    public void receiveResult(MatchingDependency matchingDependency) throws CouldNotReceiveResultException, ColumnNameMismatchException {
+        throw new CouldNotReceiveResultException("Result type is not supported.");
+    }
+
+    @Override
+    public Boolean acceptedResult(MatchingDependency matchingDependency) {
+        return false;
+    }
+
+    @Override
+    public void receiveResult(ConditionalFunctionalDependency conditionalFunctionalDependency) throws CouldNotReceiveResultException, ColumnNameMismatchException {
+        throw new CouldNotReceiveResultException("Result type is not supported.");
+    }
+
+    @Override
+    public Boolean acceptedResult(ConditionalFunctionalDependency conditionalFunctionalDependency) {
+        return false;
+    }
+
+    @Override
+    public void receiveResult(DenialConstraint denialConstraint) throws CouldNotReceiveResultException, ColumnNameMismatchException {
+        throw new CouldNotReceiveResultException("Result type is not supported.");
+    }
+
+    @Override
+    public Boolean acceptedResult(DenialConstraint denialConstraint) {
+        return false;
+    }
+
     private DependencyResultReceiver<de.hpi.isg.mdms.domain.constraints.FunctionalDependency> fdResultReceiver;
 
     @Override


### PR DESCRIPTION
Metanome introduced new metadata types as mentioned in #62. Fully supporting them is not part of this PR and might not be necessary. This PR only prevents the build from failing. 